### PR TITLE
feat: secrets.toml とchat_feedback.db をGitignoreにセキュリティ上の都合から追加

### DIFF
--- a/day1/.gitignore
+++ b/day1/.gitignore
@@ -176,3 +176,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Streamlit secrets
+secrets.toml
+
+# Database files
+chat_feedback.db


### PR DESCRIPTION
概要
Day1ディレクトリの.gitignoreファイルに、セキュリティ上重要なファイルを追加

変更内容
Day1/.gitignoreにStreamlit secretsファイル（secrets.toml）を追加
Day1/.gitignoreにデータベースファイル（chat_feedback.db）を追加
関連Issue
動作確認項目
[x] .gitignoreに追加したパターンが正しく記述されているか確認
[x] git statusで対象ファイルが無視されることを確認
スクリーンショット


特記事項
secrets.tomlはHugging Faceのトークンを含むため、確実にバージョン管理から除外する必要があります
chat_feedback.dbはローカルのデータベースファイルであり、各開発環境で個別に管理すべきです

チェックリスト
[x] コードスタイルは適切か（black, flake8のチェックをパスしているか）
[x] 新しいライブラリを追加した場合、requirements.txtを更新したか（該当なし）
[x] ユニットテストを追加・更新したか（該当なし）
[x] ドキュメントを更新したか（該当なし）